### PR TITLE
Add classes to model outputs

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,7 +2,7 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 conv_check_lmm_improper <- function(x, y, z, a, b) {
-    invisible(.Call(`_geblm_conv_check_lmm_improper`, x, y, z, a, b))
+    .Call(`_geblm_conv_check_lmm_improper`, x, y, z, a, b)
 }
 
 mv_normal <- function(mu, sigma) {

--- a/R/lm_proper.R
+++ b/R/lm_proper.R
@@ -111,6 +111,7 @@ lm_proper <- function(data,
   names(result$beta) <- stats::variable.names(fit)
   names(result$sigma) <- "sigma"
 
+  result$conv_checks <- TRUE
   result$model_type <- "lm_proper"
   result$x <- x
 

--- a/R/lm_proper.R
+++ b/R/lm_proper.R
@@ -21,8 +21,8 @@
 #' @param start_beta (Optional) Beta starting vector. Defaults to beta hat,
 #'     the frequentist estimate.
 #'
-#' @return A list containing MCMC samples from the posterior distributions of
-#'     beta and the error standard deviation sigma.
+#' @return An object of class \code{geblm} containing samples from the
+#'     posterior distributions of beta and sigma.
 #'
 #' @import stats
 #' @import checkmate
@@ -108,9 +108,13 @@ lm_proper <- function(data,
 
   result$beta <- as.data.frame(result$beta)
   result$sigma <- as.data.frame(result$sigma)
-  #result$x <- x
-  #result$y <- y
   names(result$beta) <- stats::variable.names(fit)
   names(result$sigma) <- "sigma"
+
+  result$model_type <- "lm_proper"
+  result$x <- x
+
+  class(result) <- c("geblm", class(result))
+
   return(result)
 }

--- a/R/lmm-improper.R
+++ b/R/lmm-improper.R
@@ -35,6 +35,10 @@
 #'  the fixed effects, random effects, and standard deviations for the error
 #'  term and fixed effects.
 #'
+#'  @return An object of class \code{geblm} containing samples from the
+#'     posterior distributions of the fixed effects, random effects, and
+#'     standard deviations of the fixed effects and errors.
+#'
 #'
 #' @import lme4
 #' @import stats
@@ -107,10 +111,15 @@ lmm_improper <- function(data,
   result$beta <- as.data.frame(result$beta)
   result$u <- as.data.frame(result$u)
   result$sigma <- as.data.frame(result$sigma)
-
   names(result$beta) <- stats::variable.names(x)
   names(result$u) <- paste0(names(rand_effect), "[", rownames(rand_effect), "]")
   names(result$sigma) <- c("sigma[e]", "sigma[u]")
+
+  result$model_type <- "lmm_improper"
+  result$z <- z
+  result$x <- x
+
+  class(result) <- c("geblm", class(result))
 
   return(result)
 

--- a/R/lmm-improper.R
+++ b/R/lmm-improper.R
@@ -116,8 +116,8 @@ lmm_improper <- function(data,
   names(result$sigma) <- c("sigma[e]", "sigma[u]")
 
   result$model_type <- "lmm_improper"
-  result$z <- z
   result$x <- x
+  result$z <- z
 
   class(result) <- c("geblm", class(result))
 

--- a/R/lmm-proper.R
+++ b/R/lmm-proper.R
@@ -145,8 +145,8 @@ lmm_proper <- function(data,
   names(result$sigma) <- c("sigma[e]", "sigma[u]")
 
   result$model_type <- "lmm_proper"
-  result$z <- z
   result$x <- x
+  result$z <- z
 
   class(result) <- c("geblm", class(result))
 

--- a/R/lmm-proper.R
+++ b/R/lmm-proper.R
@@ -35,10 +35,9 @@
 #'     \eqn{\theta = (\beta' u')'}, the concatenation of the fixed and random
 #'     effects coefficients. Defaults to the frequentist estimate.
 #'
-#' @return A list containing MCMC samples from the posterior distributions of
-#'  the fixed effects, random effects, and standard deviations for the error
-#'  term and fixed effects.
-#'
+#' @return An object of class \code{geblm} containing samples from the
+#'     posterior distributions of the fixed effects, random effects, and
+#'     standard deviations of the fixed effects and errors.
 #'
 #' @import lme4
 #' @import stats
@@ -141,10 +140,15 @@ lmm_proper <- function(data,
   result$beta <- as.data.frame(result$beta)
   result$u <- as.data.frame(result$u)
   result$sigma <- as.data.frame(result$sigma)
-
   names(result$beta) <- stats::variable.names(x)
   names(result$u) <- paste0(names(rand_effect), "[", rownames(rand_effect), "]")
   names(result$sigma) <- c("sigma[e]", "sigma[u]")
+
+  result$model_type <- "lmm_proper"
+  result$z <- z
+  result$x <- x
+
+  class(result) <- c("geblm", class(result))
 
   return(result)
 

--- a/man/lm_proper.Rd
+++ b/man/lm_proper.Rd
@@ -36,8 +36,8 @@ Defaults to 0.001.}
 the frequentist estimate.}
 }
 \value{
-A list containing MCMC samples from the posterior distributions of
-    beta and the error standard deviation sigma.
+An object of class \code{geblm} containing samples from the
+    posterior distributions of beta and sigma.
 }
 \description{
 Fits a Bayesian linear regression model with a normal prior on beta and a

--- a/man/lmm_improper.Rd
+++ b/man/lmm_improper.Rd
@@ -35,6 +35,10 @@ effects coefficients. Defaults to the frequentist estimate.}
 A list containing MCMC samples from the posterior distributions of
  the fixed effects, random effects, and standard deviations for the error
  term and fixed effects.
+
+ @return An object of class \code{geblm} containing samples from the
+    posterior distributions of the fixed effects, random effects, and
+    standard deviations of the fixed effects and errors.
 }
 \description{
 Fits a Bayesian linear mixed model with a flat prior on beta and improper

--- a/man/lmm_proper.Rd
+++ b/man/lmm_proper.Rd
@@ -39,9 +39,9 @@ to \code{c(0.001, 0.001)}.}
 effects coefficients. Defaults to the frequentist estimate.}
 }
 \value{
-A list containing MCMC samples from the posterior distributions of
- the fixed effects, random effects, and standard deviations for the error
- term and fixed effects.
+An object of class \code{geblm} containing samples from the
+    posterior distributions of the fixed effects, random effects, and
+    standard deviations of the fixed effects and errors.
 }
 \description{
 Fits a Bayesian linear mixed model with a normal prior on the fixed effects

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -7,17 +7,18 @@
 using namespace Rcpp;
 
 // conv_check_lmm_improper
-void conv_check_lmm_improper(Eigen::MatrixXd x, Eigen::VectorXd y, Eigen::MatrixXd z, Eigen::VectorXd a, Eigen::VectorXd b);
+bool conv_check_lmm_improper(Eigen::MatrixXd x, Eigen::VectorXd y, Eigen::MatrixXd z, Eigen::VectorXd a, Eigen::VectorXd b);
 RcppExport SEXP _geblm_conv_check_lmm_improper(SEXP xSEXP, SEXP ySEXP, SEXP zSEXP, SEXP aSEXP, SEXP bSEXP) {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Eigen::MatrixXd >::type x(xSEXP);
     Rcpp::traits::input_parameter< Eigen::VectorXd >::type y(ySEXP);
     Rcpp::traits::input_parameter< Eigen::MatrixXd >::type z(zSEXP);
     Rcpp::traits::input_parameter< Eigen::VectorXd >::type a(aSEXP);
     Rcpp::traits::input_parameter< Eigen::VectorXd >::type b(bSEXP);
-    conv_check_lmm_improper(x, y, z, a, b);
-    return R_NilValue;
+    rcpp_result_gen = Rcpp::wrap(conv_check_lmm_improper(x, y, z, a, b));
+    return rcpp_result_gen;
 END_RCPP
 }
 // mv_normal

--- a/src/conv-checks.cpp
+++ b/src/conv-checks.cpp
@@ -5,7 +5,7 @@
 using namespace Rcpp;
 
 // [[Rcpp::export]]
-void conv_check_lmm_improper(Eigen::MatrixXd x,
+bool conv_check_lmm_improper(Eigen::MatrixXd x,
                               Eigen::VectorXd y,
                               Eigen::MatrixXd z,
                               Eigen::VectorXd a,
@@ -57,10 +57,12 @@ void conv_check_lmm_improper(Eigen::MatrixXd x,
 
   }
 
+  return pass_check;
+
 }
 
 
-void conv_check_lmm_proper(Eigen::MatrixXd z,
+bool conv_check_lmm_proper(Eigen::MatrixXd z,
                             Eigen::VectorXd a){
   double ae = a(0);
   double au = a(1);
@@ -72,7 +74,8 @@ void conv_check_lmm_proper(Eigen::MatrixXd z,
   bool pass_strong_condition1 = true;
   bool pass_strong_condition2 = true;
 
-  Function msg("message");
+  bool pass_first_checks = true;
+  bool pass_second_checks = true;
 
   if ( not (n > rank_z + 2) ) pass_strong_condition1 = false;
 
@@ -81,6 +84,8 @@ void conv_check_lmm_proper(Eigen::MatrixXd z,
   if (pass_strong_condition1 and pass_strong_condition2){
     Rcout << "Conditions for geometric convergence are satisfied." << std::endl;
   } else {
+
+    pass_first_checks = false;
 
     bool pass_weak_condition1 = true;
     bool pass_weak_condition2 = true;
@@ -100,9 +105,11 @@ void conv_check_lmm_proper(Eigen::MatrixXd z,
 
     } else{
 
+      pass_second_checks = false;
       warning("Conditions for geometric convergence are not satisfied.");
     }
 
   }
 
+  return pass_first_checks or pass_second_checks;
 }

--- a/src/conv-checks.h
+++ b/src/conv-checks.h
@@ -9,13 +9,13 @@
 
 using namespace Rcpp;
 
-void conv_check_lmm_improper(Eigen::MatrixXd x,
+bool conv_check_lmm_improper(Eigen::MatrixXd x,
                               Eigen::VectorXd y,
                               Eigen::MatrixXd z,
                               Eigen::VectorXd a,
                               Eigen::VectorXd b);
 
-void conv_check_lmm_proper(Eigen::MatrixXd z,
+bool conv_check_lmm_proper(Eigen::MatrixXd z,
                            Eigen::VectorXd a);
 
 #endif

--- a/src/lmm-improper.cpp
+++ b/src/lmm-improper.cpp
@@ -52,11 +52,11 @@ List lmm_improper_cpp(Eigen::MatrixXd X,
 
   double check;
 
-  conv_check_lmm_improper(X,
-                           y,
-                           Z,
-                           lambda_prior_shape,
-                           lambda_prior_rate);
+  bool conv_checks_pass = conv_check_lmm_improper(X,
+                                                  y,
+                                                  Z,
+                                                  lambda_prior_shape,
+                                                  lambda_prior_rate);
 
   for(int i = 0; i < burnin; i++){
 
@@ -126,6 +126,7 @@ List lmm_improper_cpp(Eigen::MatrixXd X,
   return List::create(
     Named("beta") = beta_out,
     Named("u") = u_out,
-    Named("sigma") = sigma_out
+    Named("sigma") = sigma_out,
+    Named("conv_checks") = conv_checks_pass
   );
 }

--- a/src/lmm-proper.cpp
+++ b/src/lmm-proper.cpp
@@ -55,7 +55,7 @@ List lmm_proper_cpp(Eigen::MatrixXd x,
   Eigen::VectorXd eta(p + q);
   Eigen::VectorXd diff(n);
 
-  conv_check_lmm_proper(z, lambda_prior_shape);
+  bool conv_checks_pass = conv_check_lmm_proper(z, lambda_prior_shape);
 
   for(int i = 0; i < burnin; i++){
 
@@ -110,7 +110,8 @@ List lmm_proper_cpp(Eigen::MatrixXd x,
   return List::create(
     Named("beta") = beta_out,
     Named("u") = u_out,
-    Named("sigma") = sigma_out
+    Named("sigma") = sigma_out,
+    Named("conv_checks") = conv_checks_pass
   );
 
 }

--- a/tests/testthat/test-lm-proper.R
+++ b/tests/testthat/test-lm-proper.R
@@ -24,7 +24,7 @@ test_that("output has correct format",{
   expect_named(fit$beta, c("x1", "x2"))
   expect_named(fit$sigma, "sigma")
 
-  expect_is(fit, "list")
+  expect_is(fit, "geblm")
   expect_is(fit$beta, "data.frame")
   expect_is(fit$sigma, "data.frame")
 

--- a/tests/testthat/test-lmm-improper.R
+++ b/tests/testthat/test-lmm-improper.R
@@ -31,7 +31,7 @@ test_that("output has correct format", {
                              "]"))
   expect_named(fit$sigma, c("sigma[e]", "sigma[u]"))
 
-  expect_is(fit, "list")
+  expect_is(fit, "geblm")
   expect_is(fit$beta, "data.frame")
   expect_is(fit$u, "data.frame")
   expect_is(fit$sigma, "data.frame")

--- a/tests/testthat/test-lmm-proper.R
+++ b/tests/testthat/test-lmm-proper.R
@@ -32,7 +32,7 @@ test_that("output has correct format", {
                              "]"))
   expect_named(fit$sigma, c("sigma[e]", "sigma[u]"))
 
-  expect_is(fit, "list")
+  expect_is(fit, "geblm")
   expect_is(fit$beta, "data.frame")
   expect_is(fit$u, "data.frame")
   expect_is(fit$sigma, "data.frame")


### PR DESCRIPTION
Fitted models now have class `geblm` containing the samples along with:

- were convergence conditions met?
- model type: lm, lmm_improper, etc.
- x, z matrices (when appropriate)

closes #2